### PR TITLE
Add support for non-Chrome browsers

### DIFF
--- a/paper-chip-input-autocomplete.html
+++ b/paper-chip-input-autocomplete.html
@@ -273,7 +273,7 @@ Custom property | Description | Default
 				this._autocompleteClass = "hide";
 			}
 
-			_removeChip() {
+			_removeChip(event) {
 				const index = this._items.indexOf(event.detail.chipLabel);
 				if (index != -1) {
 					this.splice('_items', index, 1);

--- a/paper-chip-input-autocomplete.html
+++ b/paper-chip-input-autocomplete.html
@@ -49,6 +49,7 @@ Custom property | Description | Default
 			}
 
 			paper-item {
+				height: 0px; /* To resolve `min-height` bug on IE 11 */
 				--paper-item-selected-weight: normal;
 				--paper-item-min-height: var(--paper-chip-autocomplete-item-height, 48px);
 				--paper-item: {

--- a/paper-chip-input-autocomplete.html
+++ b/paper-chip-input-autocomplete.html
@@ -253,7 +253,7 @@ Custom property | Description | Default
 			}
 
 			_filterBySearchString(element) {
-				return element.text.toLowerCase().includes(this._inputValue.toLowerCase());
+				return element.text.toLowerCase().indexOf(this._inputValue.toLowerCase()) >= 0;
 			}
 
 			_selectPaperItem(event) {

--- a/paper-chip-input-autocomplete.html
+++ b/paper-chip-input-autocomplete.html
@@ -94,14 +94,14 @@ Custom property | Description | Default
 
 		<div>
 			<paper-input id="paperInput" label="[[label]]" on-keyup="_findItems" value="{{_inputValue}}" autofocus="{{autofocus}}">
-				<slot id="slot2" name="input" slot="prefix">
+				<div id="slot2" slot="prefix">
 					<dom-repeat items="[[_items]]">
 						<template>
 							[[item.name]]
 							<paper-chip id="paper-chip-[[item]]-[[index]]" label="[[item]]" closable$="[[closable]]" on-chip-removed="_removeChip"></paper-chip>
 						</template>
 					</dom-repeat>
-				</slot>
+				</div>
 			</paper-input>
 		</div>
 
@@ -128,7 +128,7 @@ Custom property | Description | Default
 
 			static get properties() {
 				return {
-					
+
 					/**
  					* The minimum lengt to trigger the autocomplete.
  					*/
@@ -146,7 +146,7 @@ Custom property | Description | Default
 							return [];
 						}
 					},
-					
+
 					/**
  					* If true, the paper-chips can be closed.
  					*/

--- a/paper-chip-input.html
+++ b/paper-chip-input.html
@@ -60,7 +60,7 @@ Custom property | Description | Default
 					label="[[label]]">
 			<slot id="slot" name="input" slot="prefix"></slot>
 			<div id="slot2" slot="prefix">
-				<dom-repeat items="[[items]]" id="itemsRepeater">
+				<dom-repeat items="[[items]]">
 					<template>
 						[[item.name]]
 						<paper-chip id="paper-chip-[[item]]-[[index]]" label="[[item]]" closable$="[[closable]]" on-chip-removed="_removeChip"></paper-chip>

--- a/paper-chip-input.html
+++ b/paper-chip-input.html
@@ -43,9 +43,6 @@ Custom property | Description | Default
 					font-size: var(--paper-chip-input-label-font-size, 13px);
 				}
 
-				--paper-input-container-ms-clear: {
-					display: none;
-				}
 			}
 		</style>
 

--- a/paper-chip-input.html
+++ b/paper-chip-input.html
@@ -58,9 +58,9 @@ Custom property | Description | Default
 					disabled$="[[disabled]]"
 					value="{{_value}}"
 					label="[[label]]">
-			<div slot="prefix">
-				<slot id="slot" name="input"></slot>
-				<dom-repeat items="[[items]]">
+			<slot id="slot" name="input" slot="prefix"></slot>
+			<div id="slot2" slot="prefix">
+				<dom-repeat items="[[items]]" id="itemsRepeater">
 					<template>
 						[[item.name]]
 						<paper-chip id="paper-chip-[[item]]-[[index]]" label="[[item]]" closable$="[[closable]]" on-chip-removed="_removeChip"></paper-chip>

--- a/paper-chip-input.html
+++ b/paper-chip-input.html
@@ -58,9 +58,8 @@ Custom property | Description | Default
 					disabled$="[[disabled]]"
 					value="{{_value}}"
 					label="[[label]]">
-
-			<slot id="slot" name="input" slot="prefix"></slot>
 			<div slot="prefix">
+				<slot id="slot" name="input"></slot>
 				<dom-repeat items="[[items]]">
 					<template>
 						[[item.name]]

--- a/paper-chip-input.html
+++ b/paper-chip-input.html
@@ -60,14 +60,14 @@ Custom property | Description | Default
 					label="[[label]]">
 
 			<slot id="slot" name="input" slot="prefix"></slot>
-			<slot id="slot2" name="input2" slot="prefix">
+			<div slot="prefix">
 				<dom-repeat items="[[items]]">
 					<template>
 						[[item.name]]
 						<paper-chip id="paper-chip-[[item]]-[[index]]" label="[[item]]" closable$="[[closable]]" on-chip-removed="_removeChip"></paper-chip>
 					</template>
 				</dom-repeat>
-			</slot>
+			</div>
 		</paper-input>
 
 	</template>

--- a/paper-chip-input.html
+++ b/paper-chip-input.html
@@ -42,17 +42,21 @@ Custom property | Description | Default
 					-webkit-font-smoothing: antialiased;
 					font-size: var(--paper-chip-input-label-font-size, 13px);
 				}
+
+				--paper-input-container-ms-clear: {
+					display: none;
+				}
 			}
 		</style>
 
 		<iron-a11y-keys target="paperInput" keys="enter" on-keys-pressed="_onKeyEnter"></iron-a11y-keys>
 		<iron-a11y-keys target="paperInput" keys="backspace" on-keys-pressed="_onKeyBackspace"></iron-a11y-keys>
 
-		<paper-input id="paperInput" 
-					always-float-label$="[[alwaysFloatLabel]]" 
-					no-label-float$="[[noLabelFloat]]" 
+		<paper-input id="paperInput"
+					always-float-label$="[[alwaysFloatLabel]]"
+					no-label-float$="[[noLabelFloat]]"
 					disabled$="[[disabled]]"
-					value="{{_value}}" 
+					value="{{_value}}"
 					label="[[label]]">
 
 			<slot id="slot" name="input" slot="prefix"></slot>


### PR DESCRIPTION
Fixed several issues so that `paper-chip-input` and `paper-chip-input-autocomplete` completely work properly on FF, IE, Edge. This PR will resolve the problems reported in #32 completely.