### PR TITLE
Move event of 'chip-removed' after splicing of 'items' array

### DIFF
--- a/paper-chip-input-autocomplete.html
+++ b/paper-chip-input-autocomplete.html
@@ -365,9 +365,9 @@ Custom property | Description | Default
 				if (this.items.length != 0) {
 					let lastItemIndex = this.items.length - 1;
 					let lastItemname = this.items[lastItemIndex];
-
-					this._throwChipRemovedEvent(lastItemname);
+					
 					this.splice('items', -1, 1);
+					this._throwChipRemovedEvent(lastItemname);
 				}
 			}
 


### PR DESCRIPTION
Throwing of event 'chip-removed' was before calling splice for 'items' array.

This has been moved to after calling of splice for 'items' array.